### PR TITLE
Started Fupi Modularization Of Embedder

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -43,7 +43,7 @@ RUN mkdir /home/fupi
 RUN mkdir /home/fupi_data
 
 COPY ./.env        /home/fupi/.env
-COPY ./fupi.py     /home/fupi/fupi.py
+COPY ./fupi        /home/fupi/fupi
 COPY ./searcher.py /home/fupi/searcher.py
 
 # Start Fupi Gradio search application by default:

--- a/embedder.py
+++ b/embedder.py
@@ -1,35 +1,22 @@
 #!/usr/bin/env python3
 
-import datetime
-import logging
 import os
-import time
+import logging
+import datetime
 
 from dotenv import load_dotenv, find_dotenv
-import duckdb
 from huggingface_hub import hf_hub_download
-import onnxruntime as ort
-import pandas as pd
-import pysbd
 from transformers import AutoTokenizer
-from minio import Minio
 
-from fupi import model_downloader_from_object_storage
-from fupi import ort_session_starter_for_text_embedding
-from fupi import lancedb_tables_creator
-from fupi import centroid_maker_for_arrays
-from fupi import centroid_maker_for_series
+from fupi import HuggingFaceDataset, LanceDBEmbedder
+from fupi.utils import (model_downloader_from_object_storage, 
+                        ort_session_starter_for_text_embedding)
+
 
 # docker run --rm -it --user $(id -u):$(id -g) -v $PWD:/app fupi python /app/embedder.py
 
 # Load settings from .env file:
 load_dotenv(find_dotenv())
-
-# LanceDB object storage settings:
-# os.environ['AWS_ENDPOINT']          = os.environ['PROD_ENDPOINT_S3']
-# os.environ['AWS_ACCESS_KEY_ID']     = os.environ['PROD_ACCESS_KEY_ID']
-# os.environ['AWS_SECRET_ACCESS_KEY'] = os.environ['PROD_SECRET_ACCESS_KEY']
-# os.environ['AWS_REGION']            = 'us-east-1'
 
 os.environ['AWS_ENDPOINT']          = os.environ['DEV_ENDPOINT_S3']
 os.environ['AWS_ACCESS_KEY_ID']     = os.environ['DEV_ACCESS_KEY_ID']
@@ -39,16 +26,7 @@ os.environ['ALLOW_HTTP']            = 'True'
 
 # Input data settings:
 TOTAL_NUM_TEXTS = 100
-INPUT_ITEMS_PER_BATCH = 100
-
-
-def batch_generator(item_list, items_per_batch):
-    for item in range(0, len(item_list), items_per_batch):
-        yield item_list[item:item + items_per_batch]
-
-
-def newlines_remover(text: str) -> str:
-    return text.replace('\n', ' ')
+INPUT_ITEMS_PER_BATCH = 10
 
 
 def logger_starter():
@@ -74,313 +52,42 @@ def logger_starter():
     return logger
 
 
-def create_dataset_bucket(minio_client: Minio, bucket_name: str):
-    if not minio_client.bucket_exists(bucket_name):
-        minio_client.make_bucket(bucket_name)
-
-        print(f'{bucket_name} bucket was created.')
-
-
-def init_minio() -> Minio:
-    # Initiate MinIO client:
-    endpoint = str(os.environ['AWS_ENDPOINT'])
-    secure_mode = None
-
-    if 'https' in endpoint:
-        endpoint = endpoint.replace('https://', '')
-        secure_mode = True
-    else:
-        endpoint = endpoint.replace('http://', '')
-        secure_mode = False
-    
-    minio_client = Minio(
-        endpoint,
-        access_key=os.environ['AWS_ACCESS_KEY_ID'],
-        secret_key=os.environ['AWS_SECRET_ACCESS_KEY'],
-        secure=secure_mode
-    )
-
-    return minio_client
-
-
 def main():
     # Start logging: 
     logger = logger_starter()
-    total_time = 0
-
-    # Creating LanceDB tables:
-    minio_client = init_minio()
-
-    create_dataset_bucket(
-        minio_client, 
-        bucket_name=os.environ['DEV_LANCEDB_BUCKET']
-    )
-
-    text_level_table, sentence_level_table = (
-        lancedb_tables_creator(os.environ['DEV_LANCEDB_BUCKET'])
-    )
-
     logger.info('Loading data ...')
 
     print('')
     print('Loading data ...')
     print('')
 
+    print('Downloading dataset...')
     hf_hub_download(
         repo_id='CloverSearch/cc-news-mutlilingual',
         filename='2021/bg.jsonl.gz',
         local_dir='/app/data/huggingface',
         repo_type='dataset'
     )
-
-    duckdb.create_function('newlines_remover', newlines_remover)
-
-    duckdb.sql('CREATE SEQUENCE text_id_maker START 1')
-
-    logger.info('Running DuckDB SELECT query ...')
-    print('Running DuckDB SELECT query ...')
-
-    input_list = duckdb.sql(
-        f'''
-            SELECT
-                nextval('text_id_maker') AS text_id,
-                date_publish_final AS date,
-                newlines_remover(title) AS title,
-                newlines_remover(maintext) AS text
-            FROM read_json_auto("/app/data/huggingface/2021/bg.jsonl.gz")
-            WHERE
-                date_publish_final IS NOT NULL
-                AND title IS NOT NULL
-                AND maintext IS NOT NULL
-                AND title NOT LIKE '%...'
-            LIMIT {TOTAL_NUM_TEXTS}
-        '''
-    ).to_arrow_table().to_pylist()
-
+    print('Downloading model...')
     model_downloader_from_object_storage(
         os.environ['DEV_MODELS_BUCKET'],
         'bge-m3'
     )
 
     ort_session = ort_session_starter_for_text_embedding()
-
-    # Initialize tokenizer:
     tokenizer = AutoTokenizer.from_pretrained('ddmitov/bge_m3_dense_colbert_onnx')
 
-    # Create LanceDB tables:
-    text_level_table, sentence_level_table = (
-        lancedb_tables_creator(os.environ['DEV_LANCEDB_BUCKET'])
-    )
-
-    # Get input data: 
-    batch_list = list(
-        batch_generator(
-            input_list,
-            INPUT_ITEMS_PER_BATCH
-        )
-    )
-
-    # Initialize sentence segmenter:
-    segmenter = pysbd.Segmenter(language='bg', clean=False)
-
-    print('')
-
+    print('Embedding dataset...')
     try:
-        batch_number = 0
-        total_batches = len(batch_list)
+        dataset = HuggingFaceDataset(path="/app/data/huggingface/2021/bg.jsonl.gz", 
+                                     batch_size=INPUT_ITEMS_PER_BATCH, 
+                                     num_samples=TOTAL_NUM_TEXTS)
 
-        # Iterate over all batches of texts:
-        for batch in batch_list:
-            batch_embedding_start = time.time()
-
-            batch_number += 1
-
-            text_list = []
-            sentence_list = []
-
-            item_number = 0
-
-            # Iterate over all texts:
-            for item in batch:
-                item_number += 1
-
-                item_embedding_start = time.time()
-
-                # Split every text to sentences:
-                sentences = segmenter.segment(str(item['text']))
-
-                # Get text-level table data without embeddings:
-                text_item = {}
-
-                text_item['text_id'] = item['text_id']
-                text_item['date']    = item['date']
-                text_item['title']   = item['title']
-
-                # Prepare text-level list of dictionaries:
-                text_list.append(text_item)
-
-                total_sentences = len(sentences)
-                sentence_number = 0
-
-                # Iterate over all sentences in a text:
-                for sentence in sentences:
-                    sentence_number += 1
-
-                    # Tokenize input sentence:
-                    tokenized_input = tokenizer(
-                        sentence,
-                        truncation=True,
-                        return_tensors='np'
-                    )
-
-                    # Get sentence-level embeddings:
-                    onnx_input = {
-                        key: ort.OrtValue.ortvalue_from_numpy(value)
-                        for key, value in tokenized_input.items()
-                    }
-
-                    outputs = ort_session.run(None, onnx_input)
-
-                    # Get sentence-level dense data:
-                    dense_embedding = outputs[0][0]
-
-                    sentence_item = {}
-
-                    sentence_item['text_id']         = item['text_id']
-                    sentence_item['sentence_id']     = sentence_number
-                    sentence_item['sentence']        = sentence
-                    sentence_item['dense_embedding'] = dense_embedding
-
-                    # Get sentence-level ColBERT data:
-                    colbert_embeddings = outputs[1][0]
-
-                    # ColBERT embeddings for sentences are
-                    # centroids of the multiple ColBERT embeddings
-                    # produced for every sentence:
-                    colbert_centroid = (
-                        centroid_maker_for_arrays(colbert_embeddings)
-                    )
-
-                    sentence_item['colbert_embedding'] = colbert_centroid
-
-                    sentence_list.append(sentence_item)
-
-                    # Log sentence embedding data:
-                    print(
-                        f'batch {batch_number}/{total_batches} - ' +
-                        f'item {item_number}/{INPUT_ITEMS_PER_BATCH} - ' +
-                        f'sentence {sentence_number}/{total_sentences}'
-                    )
-
-                    logger.info(
-                        f'batch {batch_number}/{total_batches} - ' +
-                        f'item {item_number}/{INPUT_ITEMS_PER_BATCH} - ' +
-                        f'sentence {sentence_number}/{total_sentences}'
-                    )
-
-                # Get runtime data for logging:
-                item_embedding_end = time.time()
-
-                item_embedding_time = round(
-                    (item_embedding_end - item_embedding_start),
-                    3
-                )
-
-                item_embedding_time_string = str(
-                    datetime.timedelta(seconds=item_embedding_time)
-                )
-
-                print('')
-
-                print(
-                    f'batch {batch_number}/{total_batches} - ' +
-                    f'item {item_number}/{INPUT_ITEMS_PER_BATCH} - ' +
-                    f'embedded for {item_embedding_time_string}'
-                )
-
-                print('')
-
-                logger.info(
-                    f'batch {batch_number}/{total_batches} - ' +
-                    f'item {item_number}/{INPUT_ITEMS_PER_BATCH} - ' +
-                    f'embedded for {item_embedding_time_string}'
-                )
-
-            # Data processing for the sentence-level LanceDB table:
-            sentence_dataframe = pd.DataFrame(sentence_list)
-
-            # Data processing for the text-level LanceDB table.
-            # Dense embeddings for the text-level LanceDB table are
-            # centroids of the sentence-level dense embeddings:
-            aggregated_text_dataframe = (
-                sentence_dataframe.groupby(
-                    [
-                        'text_id'
-                    ]
-                ).agg(
-                    {
-                        'dense_embedding': [centroid_maker_for_series]
-                    }
-                )
-            ).reset_index()
-
-            aggregated_text_dataframe.columns = (
-                aggregated_text_dataframe.columns.get_level_values(0)
-            )
-
-            text_dataframe = pd.DataFrame(text_list)
-
-            combined_text_dataframe = pd.merge(
-                text_dataframe,
-                aggregated_text_dataframe,
-                on='text_id',
-                how='left'
-            )
-
-            # Add data to the LanceDB tables:
-            sentence_level_table.add(sentence_dataframe)
-            text_level_table.add(combined_text_dataframe)
-
-            # Calculate and log batch processing time:
-            batch_embedding_end = time.time()
-
-            batch_embedding_time = round(
-                (batch_embedding_end - batch_embedding_start),
-                3
-            )
-
-            batch_embedding_time_string = str(
-                datetime.timedelta(seconds=batch_embedding_time)
-            )
-
-            total_time = round(total_time + batch_embedding_time, 3)
-            total_time_string = str(datetime.timedelta(seconds=total_time))
-
-            print(
-                f'batch {batch_number}/{total_batches} ' +
-                f'embedded for {batch_embedding_time_string}'
-            )
-
-            print(f'total time: {total_time_string}')
-            print('')
-
-            logger.info(
-                f'batch {batch_number}/{total_batches} ' +
-                f'embedded for {batch_embedding_time_string}'
-            )
-
-            logger.info(f'total time: {total_time_string}')
+        embedder = LanceDBEmbedder(tokenizer=tokenizer, model=ort_session)
+        embedder.embed(dataset)
     except (KeyboardInterrupt, SystemExit):
         print('\n')
         exit(0)
-
-    # Compact all newly created LanceDB tables:
-    logger.info('Compacting LanceDB tables ...')
-
-    print('Compacting LanceDB tables ...')
-
-    text_level_table.compact_files()
-    sentence_level_table.compact_files()
 
     logger.info('All LanceDB tables are compacted.')
 

--- a/fupi/__init__.py
+++ b/fupi/__init__.py
@@ -1,0 +1,2 @@
+from fupi.data import HuggingFaceDataset
+from fupi.embedders import LanceDBEmbedder

--- a/fupi/data.py
+++ b/fupi/data.py
@@ -17,6 +17,14 @@ class Dataset(ABC):
 
 
 class HuggingFaceDataset(Dataset):
+    """HuggingFace dataset handler that reads it from a file and splits it into batches of sentences.
+
+    Args:
+        path (str): Path to HuggingFace dataset file.
+        num_samples (int, optional): Number of sample to take. Defaults to -1, which means all samples.
+        batch_size (int, optional): Sentences batch size. Defaults to 1.
+        segmenter (Any, optional): Segmenter to use. Defaults to pysbd.Segmenter.
+    """
 
     def __init__(self, path: str, num_samples: int = -1, batch_size: int = 1, segmenter: Any = None):
         self._path = path

--- a/fupi/data.py
+++ b/fupi/data.py
@@ -1,0 +1,92 @@
+from typing import List, Any, Dict
+from abc import ABC, abstractmethod
+
+import pysbd
+import duckdb
+
+
+class Dataset(ABC):
+        
+    @abstractmethod
+    def __getitem__(self, index: int):
+        pass
+    
+    @abstractmethod
+    def __len__(self):
+        pass
+
+
+class HuggingFaceDataset(Dataset):
+
+    def __init__(self, path: str, num_samples: int = -1, batch_size: int = 1, segmenter: Any = None):
+        self._path = path
+        self._num_samples = num_samples
+
+        if not segmenter:
+            self._segmenter = pysbd.Segmenter(language='bg', clean=False)
+        else:
+            self._segmenter = segmenter
+
+        duckdb.create_function('newlines_remover', self._newlines_remover)
+        duckdb.sql('CREATE SEQUENCE text_id_maker START 1')
+
+        self._entries = duckdb.sql(
+            self. _get_dataset_query()
+        ).to_arrow_table().to_pylist()
+
+        self._entries = self._split_into_sentences(self._entries)
+        self._entries = self._create_batches(self._entries, batch_size)
+
+    def __getitem__(self, index: int):
+        return self._entries[index]
+
+    def __len__(self):
+        return len(self._entries)
+    
+    def _newlines_remover(self, text: str) -> str:
+        return text.replace('\n', ' ')
+    
+    def _get_dataset_query(self):
+        query = f'''
+            SELECT
+                nextval('text_id_maker') AS text_id,
+                date_publish_final AS date,
+                newlines_remover(title) AS title,
+                newlines_remover(maintext) AS text
+            FROM read_json_auto("{self._path}")
+            WHERE
+                date_publish_final IS NOT NULL
+                AND title IS NOT NULL
+                AND maintext IS NOT NULL
+                AND title NOT LIKE '%...'
+        '''
+        if self._num_samples > 0:
+            return query + f' LIMIT {self._num_samples}'
+
+        return query
+    
+    def _create_batches(self, entries: List[Any], batch_size: int):
+        if batch_size == 1:
+            return entries
+        
+        batches = []
+        for i in range(0, len(entries), batch_size):
+            batches.append(entries[i:i + batch_size])
+
+        return batches
+    
+    def _split_into_sentences(self, entries: List[Dict[str, Any]]):
+        result = []
+        sentence_id = 0
+
+        for entry in entries:
+            sentences = self._segmenter.segment(entry['text'])
+            for sentence in sentences:
+                sentence_id += 1
+                result.append({"date": entry["date"],
+                               "text_id": entry["text_id"], 
+                               "title": entry["title"], 
+                               "sentence_id": sentence_id,
+                               "sentence": sentence})
+                
+        return result

--- a/fupi/embedders.py
+++ b/fupi/embedders.py
@@ -8,6 +8,7 @@ import pandas as pd
 from torch import nn
 from tqdm import tqdm
 import onnxruntime as ort
+from transformers import PreTrainedTokenizer
 from onnxruntime.capi.onnxruntime_inference_collection import InferenceSession
 
 from fupi.data import Dataset
@@ -24,14 +25,25 @@ class Embedder(ABC):
 
 
 class LanceDBEmbedder(ABC):
+    """Creates text and sentence embeddings and saves them into LanceDB.
 
-    def __init__(self, tokenizer, model):
+    Args:
+        tokenizer (PreTrainedTokenizer): HuggingFace tokenizer.
+        model (InferenceSession): ONNX Inference session.
+    """
+
+    def __init__(self, tokenizer: PreTrainedTokenizer, model: InferenceSession):
         self._tokenizer = tokenizer
         self._model = model
 
         self._create_bucket()
 
     def embed(self, dataset: Dataset):
+        """Creates embeddings from dataset and saves them into LanceDB.
+
+        Args:
+            dataset (Dataset): Fupi Dataset object.
+        """
         batches = tqdm(dataset, total=len(dataset))
         batches.set_description("Creating embeddings")
         sentences_list = []

--- a/fupi/embedders.py
+++ b/fupi/embedders.py
@@ -1,0 +1,123 @@
+import os
+import copy
+from typing import Dict
+from abc import ABC, abstractmethod
+
+import numpy as np
+import pandas as pd
+from torch import nn
+from tqdm import tqdm
+import onnxruntime as ort
+from onnxruntime.capi.onnxruntime_inference_collection import InferenceSession
+
+from fupi.data import Dataset
+from fupi.utils import (lancedb_tables_creator, 
+                        create_dataset_bucket, 
+                        init_minio)
+
+
+class Embedder(ABC):
+    
+    @abstractmethod
+    def embed(self, dataset: Dataset, model: nn.Module):
+        pass
+
+
+class LanceDBEmbedder(ABC):
+
+    def __init__(self, tokenizer, model):
+        self._tokenizer = tokenizer
+        self._model = model
+
+        self._create_bucket()
+
+    def embed(self, dataset: Dataset):
+        batches = tqdm(dataset, total=len(dataset))
+        batches.set_description("Creating embeddings")
+        sentences_list = []
+
+        # Create embeddings for each batch of sentences.
+        for i, batch in enumerate(batches):
+            sentences_batch = copy.deepcopy(batch)
+            tokens = self._tokenizer([sample["sentence"] for sample in sentences_batch], 
+                               padding="longest", 
+                               return_tensors="np")
+            dense_embeddings, colbert_centroids = self._get_embeddings(tokens)
+
+            for i in range(len(sentences_batch)):
+                sentences_batch[i]["dense_embedding"] = dense_embeddings[i]
+                sentences_batch[i]["colbert_embedding"] = colbert_centroids[i]
+
+            sentences_list.extend(sentences_batch)
+
+        sentences_df = pd.DataFrame(sentences_list)
+        texts_df = self._create_texts_dataframe(sentences_df)
+
+        self._add_to_lancedb(sentence_dataframe=sentences_df, 
+                             texts_dataframe=texts_df)
+
+    def _create_bucket(self):
+        minio_client = init_minio()
+        create_dataset_bucket(
+            minio_client, 
+            bucket_name=os.environ['DEV_LANCEDB_BUCKET']
+        )
+
+    def _get_embeddings(self, sequences: Dict[str, np.ndarray]):
+        inputs_onnx = {k: ort.OrtValue.ortvalue_from_numpy(v) for k, v in sequences.items()}
+
+        if isinstance(self._model, InferenceSession):
+            outputs = self._model.run(None, inputs_onnx)
+        else:
+            raise Exception("We are currently only using ONNX InferenceSession objects for embedding.")
+
+        dense_embeddings, colbert_embeddings = outputs
+        colbert_centroids = np.average(colbert_embeddings, axis=1)
+        
+        return dense_embeddings, colbert_centroids
+
+    def _create_texts_dataframe(self, sentences_dataframe: pd.DataFrame):
+        texts_df = sentences_dataframe.drop_duplicates(subset=["text_id"])
+        texts_df = texts_df.drop(columns=["sentence_id", 
+                                          "sentence", 
+                                          "dense_embedding", 
+                                          "colbert_embedding"])
+
+        aggregated_texts_df = (
+            sentences_dataframe.groupby(
+                [
+                    'text_id'
+                ]
+            ).agg(
+                {
+                    'dense_embedding': [self._centroid_maker_for_series]
+                }
+            )
+        ).reset_index()
+        aggregated_texts_df.columns = aggregated_texts_df.columns.get_level_values(0)
+        texts_df = pd.merge(
+            texts_df,
+            aggregated_texts_df,
+            on='text_id',
+            how='left'
+        )
+
+        return texts_df
+
+    def _add_to_lancedb(self, sentence_dataframe: pd.DataFrame, texts_dataframe: pd.DataFrame):
+        text_level_table, sentence_level_table = (
+            lancedb_tables_creator(os.environ['DEV_LANCEDB_BUCKET'])
+        )
+
+        sentence_level_table.add(sentence_dataframe)
+        text_level_table.add(texts_dataframe)
+
+        text_level_table.compact_files()
+        sentence_level_table.compact_files()
+
+    @staticmethod
+    def _centroid_maker_for_series(group: pd.Series) -> list:
+        embeddings_list = group.tolist()
+        average_embedding_list = np.average(embeddings_list, axis=0).tolist()
+
+        return average_embedding_list

--- a/fupi/utils.py
+++ b/fupi/utils.py
@@ -1,34 +1,108 @@
-#!/usr/bin/env python3
-
-from multiprocessing import cpu_count
 import os
+from multiprocessing import cpu_count
 
 import duckdb
-from huggingface_hub import hf_hub_download
 import lancedb
-from minio import Minio
 import numpy as np
-import onnxruntime as ort
 import pandas as pd
 import pyarrow as pa
+from minio import Minio
+import onnxruntime as ort
 
 
-def model_downloader_from_hugging_face() -> True:
-    hf_hub_download(
-        repo_id='ddmitov/bge_m3_dense_colbert_onnx',
-        filename='model.onnx',
-        local_dir='/app/data/model',
-        repo_type='model'
+def lancedb_tables_creator(
+    lancedb_bucket_name: str
+) -> tuple[lancedb.table.Table, lancedb.table.Table]:
+    lance_db = lancedb.connect(f's3://{lancedb_bucket_name}/')
+
+    text_level_table_schema = pa.schema(
+        [
+            pa.field('text_id',         pa.int64()),
+            pa.field('date',            pa.date32()),
+            pa.field('title',           pa.utf8()),
+            pa.field('dense_embedding', pa.list_(pa.float32(), 1024))
+        ]
     )
 
-    hf_hub_download(
-        repo_id='ddmitov/bge_m3_dense_colbert_onnx',
-        filename='model.onnx_data',
-        local_dir='/app/data/model',
-        repo_type='model'
+    # Define LanceDB table schemas:
+    sentence_level_table_schema = pa.schema(
+        [
+            pa.field('text_id',           pa.int64()),
+            pa.field('sentence_id',       pa.int64()),
+            pa.field('sentence',          pa.utf8()),
+            pa.field('dense_embedding',   pa.list_(pa.float32(), 1024)),
+            pa.field('colbert_embedding', pa.list_(pa.float32(), 1024))
+        ]
     )
 
-    return True
+    # Initialize LanceDB tables:
+    text_level_table = lance_db.create_table(
+        'text-level-new',
+        schema=text_level_table_schema,
+        mode='overwrite'
+    )
+
+    sentence_level_table = lance_db.create_table(
+        'sentence-level-new',
+        schema=sentence_level_table_schema,
+        mode='overwrite'
+    )
+
+    return text_level_table, sentence_level_table
+
+
+def create_dataset_bucket(minio_client: Minio, bucket_name: str):
+    if not minio_client.bucket_exists(bucket_name):
+        minio_client.make_bucket(bucket_name)
+
+        print(f'{bucket_name} bucket was created.')
+
+
+def init_minio() -> Minio:
+    # Initiate MinIO client:
+    endpoint = str(os.environ['AWS_ENDPOINT'])
+    secure_mode = None
+
+    if 'https' in endpoint:
+        endpoint = endpoint.replace('https://', '')
+        secure_mode = True
+    else:
+        endpoint = endpoint.replace('http://', '')
+        secure_mode = False
+    
+    minio_client = Minio(
+        endpoint,
+        access_key=os.environ['AWS_ACCESS_KEY_ID'],
+        secret_key=os.environ['AWS_SECRET_ACCESS_KEY'],
+        secure=secure_mode
+    )
+
+    return minio_client
+
+
+def ort_session_starter_for_text_embedding() -> ort.InferenceSession:
+    # Set ONNX runtime session configuration:
+    onnxrt_options = ort.SessionOptions()
+
+    onnxrt_options.execution_mode = ort.ExecutionMode.ORT_SEQUENTIAL
+    onnxrt_options.intra_op_num_threads = cpu_count()
+
+    onnxrt_options.graph_optimization_level = (
+        ort.GraphOptimizationLevel.ORT_ENABLE_ALL
+    )
+
+    onnxrt_options.add_session_config_entry(
+        'session.intra_op.allow_spinning', '1'
+    )
+
+    # Initialize ONNX runtime session:
+    ort_session = ort.InferenceSession(
+        '/tmp/bge-m3/model.onnx',
+        sess_ptions=onnxrt_options,
+        providers=['CPUExecutionProvider']
+    )
+
+    return ort_session
 
 
 def model_downloader_from_object_storage(
@@ -65,86 +139,6 @@ def model_downloader_from_object_storage(
         )
 
     return True
-
-
-def lancedb_tables_creator(
-    lancedb_bucket_name: str
-) -> tuple[lancedb.table.Table, lancedb.table.Table]:
-    lance_db = lancedb.connect(f's3://{lancedb_bucket_name}/')
-
-    text_level_table_schema = pa.schema(
-        [
-            pa.field('text_id',         pa.int64()),
-            pa.field('date',            pa.date32()),
-            pa.field('title',           pa.utf8()),
-            pa.field('dense_embedding', pa.list_(pa.float32(), 1024))
-        ]
-    )
-
-    # Define LanceDB table schemas:
-    sentence_level_table_schema = pa.schema(
-        [
-            pa.field('text_id',           pa.int64()),
-            pa.field('sentence_id',       pa.int64()),
-            pa.field('sentence',          pa.utf8()),
-            pa.field('dense_embedding',   pa.list_(pa.float32(), 1024)),
-            pa.field('colbert_embedding', pa.list_(pa.float32(), 1024))
-        ]
-    )
-
-    # Initialize LanceDB tables:
-    text_level_table = lance_db.create_table(
-        'text-level',
-        schema=text_level_table_schema,
-        mode='overwrite'
-    )
-
-    sentence_level_table = lance_db.create_table(
-        'sentence-level',
-        schema=sentence_level_table_schema,
-        mode='overwrite'
-    )
-
-    return text_level_table, sentence_level_table
-
-
-def ort_session_starter_for_text_embedding() -> ort.InferenceSession:
-    # Set ONNX runtime session configuration:
-    onnxrt_options = ort.SessionOptions()
-
-    onnxrt_options.execution_mode = ort.ExecutionMode.ORT_SEQUENTIAL
-    onnxrt_options.intra_op_num_threads = cpu_count()
-
-    onnxrt_options.graph_optimization_level = (
-        ort.GraphOptimizationLevel.ORT_ENABLE_ALL
-    )
-
-    onnxrt_options.add_session_config_entry(
-        'session.intra_op.allow_spinning', '1'
-    )
-
-    # Initialize ONNX runtime session:
-    ort_session = ort.InferenceSession(
-        '/tmp/bge-m3/model.onnx',
-        sess_ptions=onnxrt_options,
-        providers=['CPUExecutionProvider']
-    )
-
-    return ort_session
-
-
-def centroid_maker_for_arrays(embeddings_list: np.ndarray) -> list:
-    average_embedding_list = np.average(embeddings_list, axis=0).tolist()
-
-    return average_embedding_list
-
-
-def centroid_maker_for_series(group: pd.Series) -> list:
-    embeddings_list = group.tolist()
-
-    average_embedding_list = np.average(embeddings_list, axis=0).tolist()
-
-    return average_embedding_list
 
 
 def fupi_dense_vectors_searcher(
@@ -211,7 +205,7 @@ def fupi_colbert_centroids_searcher(
     sentence_level_table: lancedb.table.Table,
     query_colbert_embeddings: np.ndarray
 ) -> pd.DataFrame:
-    query_colbert_centroid = centroid_maker_for_arrays(query_colbert_embeddings)
+    query_colbert_centroid = np.average(query_colbert_embeddings, axis=0).tolist()
 
     colbert_initial_dataframe = sentence_level_table.search(
         query_colbert_centroid,

--- a/fupi/utils.py
+++ b/fupi/utils.py
@@ -37,13 +37,13 @@ def lancedb_tables_creator(
 
     # Initialize LanceDB tables:
     text_level_table = lance_db.create_table(
-        'text-level-new',
+        'text-level',
         schema=text_level_table_schema,
         mode='overwrite'
     )
 
     sentence_level_table = lance_db.create_table(
-        'sentence-level-new',
+        'sentence-level',
         schema=sentence_level_table_schema,
         mode='overwrite'
     )

--- a/searcher.py
+++ b/searcher.py
@@ -17,9 +17,10 @@ import pandas as pd
 from transformers import AutoTokenizer, M2M100Tokenizer
 import uvicorn
 
-from fupi import model_downloader_from_object_storage
-from fupi import fupi_dense_vectors_searcher
-from fupi import fupi_colbert_centroids_searcher
+from fupi.utils import (model_downloader_from_object_storage, 
+                        fupi_dense_vectors_searcher,
+                        fupi_colbert_centroids_searcher)
+
 
 # Start the application for local development at http://0.0.0.0:7860/ using:
 # docker run --rm -it --user $(id -u):$(id -g) -v $PWD:/app -p 7860:7860 fupi python /app/searcher.py


### PR DESCRIPTION
## Modularization Of Fupi Embedder

### 1. Added LanceDBEmbedder and Dataset abstraction
Here is an example for how to use the newly added `LanceDBEmbedder`:
```python
from fupi import HuggingFaceDataset, LanceDBEmbedder
from fupi.utils import ort_session_starter_for_text_embedding


dataset = HuggingFaceDataset(path="/app/data/huggingface/2021/bg.jsonl.gz", batch_size=10, num_samples=100)

model = ort_session_starter_for_text_embedding()
tokenizer = AutoTokenizer.from_pretrained('ddmitov/bge_m3_dense_colbert_onnx')

embedder = LanceDBEmbedder(tokenizer=tokenizer, model=model)
embedder.embed(dataset)
```
We can generalize the dataset structure and read all kinds of datasets. This one is currently only working for a downloaded HuggingFace file.

Additionally, `LanceDBEmbedder` is currently logging via [tqdm](https://pypi.org/project/tqdm/). When the project is ran with Docker Compose, to see the status of the embedding, I am running these commands:
```bash
docker compose up -d
docker attach --sig-proxy=false fupi-embedder-1
```

The code snippet above is added to `embedder.py`.